### PR TITLE
Set overlay text all at once

### DIFF
--- a/source/forever/display/Overlay.hx
+++ b/source/forever/display/Overlay.hx
@@ -55,17 +55,12 @@ class Overlay extends TextField
 
 		if (visible)
 		{
-			text = ''; // set up the text itself
-			if (displayFps) // Framerate
-				text += '${times.length} FPS\n';
-			#if !neko // Current Game State
-			if (displayExtra && FlxG.state != null) {
-				text += 'State: ${Type.getClassName(Type.getClass(FlxG.state))}\n';
-				text += 'Objects: ${FlxG.state.countLiving()} (Dead: ${FlxG.state.countDead()})\n';
-			}
+			text = '${times.length} FPS\n' // Framerate
+			#if !neko
+			+ (displayExtra ? 'State: ${Type.getClassName(Type.getClass(FlxG.state))}\n' : "")
+			+ (displayExtra ? 'Objects: ${FlxG.state.countLiving()} (Dead: ${FlxG.state.countDead()})\n' : "")
 			#end
-			if (displayMemory) // Current and Total Memory Usage
-				text += '${formatBytes(mem)} / ${formatBytes(memPeak)}\n';
+			+ (displayMemory ? '${formatBytes(mem)} / ${formatBytes(memPeak)}\n' : "")
 		}
 	}
 


### PR DESCRIPTION
due to an issue with string allocation in current haxe, using the `+=` operator in strings **may or may not** cause unintended behaviour or straight up memory leaks, this fixes it by just reverting back to what legacy was doing